### PR TITLE
Ignore more files from the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -25,3 +25,15 @@ DerivedData
 #
 node_modules/
 npm-debug.log
+
+# image files
+*.gif
+*.jpg
+*.png
+
+# assorted non-permanent files
+*.swp
+coverage/
+
+# lockfile - yarn ignores the lockfile when installing, so there's no need to publish it
+yarn.lock


### PR DESCRIPTION
First off, thanks for working on this library! We just added it to our app and are quite impressed.

Now, on to the reason for my PR…

- The current npm package (1.0.1) is 2.8 MB, unpacked.
- By ignoring the screenshots, coverage, and yarn lockfile, that shrinks down to 131.6 KB.

(We're good to ignore the lockfile from npm because yarn only reads lockfiles at the top-level project; ie, running `yarn` in this repo would use the lockfile, but running `yarn` in my app wouldn't use your versions.)

