### PR TITLE
Remove android offset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-popover-view",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A <Popover /> component for react-native",
   "main": "src/index.js",
   "author": "Peter Steffey <steffeydev@icloud.com> (https://github.com/steffeydev)",

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -57,14 +57,13 @@ export function runAfterChange(getFirst, second, func) {
 }
 
 export function waitForNewRect(ref, initialRect, onFinish) {
-  let androidOffset = isIOS() ? 0 : StatusBar.currentHeight;
   runAfterChange(callback => {
     NativeModules.UIManager.measure(findNodeHandle(ref), (x0, y0, width, height, x, y) => {
-      callback(new Rect(x, y - androidOffset, width, height));
+      callback(new Rect(x, y, width, height));
     })
   }, initialRect, () => {
     NativeModules.UIManager.measure(findNodeHandle(ref), (x0, y0, width, height, x, y) => {
-      onFinish(new Rect(x, y - androidOffset, width, height))
+      onFinish(new Rect(x, y, width, height))
     })
   });
 }


### PR DESCRIPTION
We've been using this Popover component in our app and have noticed that the popover arrow is vertically misaligned on android. This PR aims to fix that.

Before | After
-- | --
<img width="425" alt="screen shot 2018-08-12 at 9 55 19 pm" src="https://user-images.githubusercontent.com/24640726/44010839-7ee9baf2-9e7a-11e8-99f9-c153d57c7113.png"> | <img width="423" alt="screen shot 2018-08-12 at 9 52 14 pm" src="https://user-images.githubusercontent.com/24640726/44010850-92e52d20-9e7a-11e8-8881-15a21135c379.png">
