### PR TITLE
added portrait-upside-down to Modal supportedOrientations

### DIFF
--- a/src/Popover.js
+++ b/src/Popover.js
@@ -808,7 +808,7 @@ class Popover extends React.Component {
 
     if (this.props.showInModal) {
       return (
-        <Modal transparent={true} supportedOrientations={['portrait', 'landscape']} hardwareAccelerated={true} visible={this.state.visible} onRequestClose={this.props.onClose}>
+        <Modal transparent={true} supportedOrientations={['portrait', 'portrait-upside-down', 'landscape']} hardwareAccelerated={true} visible={this.state.visible} onRequestClose={this.props.onClose}>
           {contentView}
         </Modal>
       );


### PR DESCRIPTION
Add support for portrait-upside-down orientation on iPad.
Without this change the UI will flip upside down when presenting a popover in this orientation.