### PR TITLE
Fixed bug causing tooltips to display off screen

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -325,7 +325,7 @@ class JSModalPopover extends Component<JSModalPopoverProps, ModalPopoverState> {
       return (
         <View
           pointerEvents="box-none"
-          style={[styles.container, { left: 0 }]}
+          style={[styles.container, { top: 0 }]}
           ref={this.containerRef}>
           <AdaptivePopover
             onCloseComplete={() => {


### PR DESCRIPTION
When using PopoverMode.TOOLTIP mode the view is displayed offscreen as the getDisplayAreaOffset() callback is referencing a view which appears off screen (leading the displayArea to also be off screen). This PR fixed the issue by moving the referenced View back onto the screen.

This PR may fix Issues #92 