### PR TITLE
Fix tooltip positioning

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -1130,6 +1130,7 @@ class BasePopover extends Component<BasePopoverProps, BasePopoverState> {
 
     const containerStyle = {
       ...styles.container,
+      top: -1 * FIX_SHIFT,
       opacity: animatedValues.fade
     };
 


### PR DESCRIPTION
I tested the change in commit `1d273d3` and it looks like there was a small issue with it. I also found my original understanding of the problem was incorrect. Here's an updated fix and a better explanation. 

- Line 328 in Popover.tsx was shifted by -1 * FIX_SHIFT `<View
          pointerEvents="box-none"
          style={styles.container}` (`styles.container` originally had a `-1 * FIX_SHIFT` as part of it)
- Line 1162 in Popover.tsx was shifted by -1 * FIX_SHIFT `<View pointerEvents="box-none" style={[styles.container, { top: -1 * FIX_SHIFT }]}>`
- Line 1170 in Popover.tsx was shifted by -1 * FIX_SHIFT  `<Animated.View pointerEvents="box-none" style={containerStyle}>` (`styles.container` originally had a `-1 * FIX_SHIFT` as part of it)
- The means the popover is shifted by -3 * FIX_SHIFT, but all the calculations try to shift it by 2 * FIX_SHIFT, so we have an extra -1 * FIX_SHIFT
- The proper place to fix this is on line 328, in order to make JSModalPopover (line 305) and RNModalPopover (line 229 - which has no extra -1 * FIX_SHIFT) equal
- Commit  `1d273d3` did fix the issue on line 328, but it accidentally removed the -1 * FIX_SHIFT at line 1170, which we still need
- This PR adds the -1 * FIX_SHIFT back to the `containerStyle` which line 1170 references
