### PR TITLE
Give arrow z-index of 1 so it appears over the popover shadow

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -1090,6 +1090,7 @@ class BasePopover extends Component<BasePopoverProps, BasePopoverState> {
     const arrowViewStyle = {
       // eslint-disable-next-line
       position: 'absolute' as "absolute",
+      zIndex: 1,
       top: 0,
       ...(I18nManager.isRTL ? { right: 0 } : { left: 0 }),
       width: arrowWidth,


### PR DESCRIPTION
In commit  [722d97a3e1790110f9d3f75adfced3ebac6e3573](https://github.com/SteffeyDev/react-native-popover-view/commit/722d97a3e1790110f9d3f75adfced3ebac6e3573) the position of the arrow and pop-over were swapped in the JSX code. This change caused the arrow to now appear under the popover's shadow as opposed to over it which is inconsistent with the design previous versions of react-native-popover-view provided. This may lead to issues with the application design for those trying to upgrade from older version to 4.0.0. 