### PR TITLE
Fix touch events through background for Mode.TOOLTIP

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -1155,6 +1155,7 @@ class BasePopover extends Component<BasePopoverProps, BasePopoverState> {
     return (
       <View pointerEvents="box-none" style={[styles.container, { top: -1 * FIX_SHIFT }]}>
         <View
+          pointerEvents="box-none"
           style={[styles.container, { top: FIX_SHIFT, flex: 1 }]}
           onLayout={evt => this.props.onDisplayAreaChanged(new Rect(
             evt.nativeEvent.layout.x,


### PR DESCRIPTION
When using mode={PopoverMode.TOOLTIP}, not actually all events go through containers - one of them is missing pointerEvents="box-none" to allow accessing background views.