### PR TITLE
fix: Declare prop-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "jest-serializer-enzyme": "^1.0.0",
     "patch-package": "^6.2.2",
     "postinstall-postinstall": "^2.1.0",
+    "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-addons-test-utils": "^15.6.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
We consume prop-types in Popover, so we need to declare the dependency.