### PR TITLE
feat(popover): expose a requestClose method to close the popover programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,33 @@ function App() {
 }
 ```
 
+### Showing popover from an element (alternative approach)
+
+If you prefer to let the `Popover` handle opening from an element but need to close it programmatically, you can also use the exposed method `requestClose` to close it manually.
+
+```jsx
+import React, { useRef } from 'react';
+import Popover from 'react-native-popover-view';
+
+function App() {
+  const popoverRef = useRef();
+
+  return (
+    <Popover
+      ref={popoverRef}
+      from={(
+        <TouchableOpacity>
+          <Text>Press here to open popover!</Text>
+        </TouchableOpacity>
+      )}>
+      <TouchableOpacity onPress={() => popoverRef.current.requestClose()}>
+        <Text>Tap to close me</Text>
+      </TouchableOpacity>
+    </Popover>
+  );
+}
+```
+
 ### Showing popover from a reference to an element
 
 If you need even more control (e.g. having the `Popover` and `Touchable` in complete different parts of the node hierarchy), you can just pass in a normal `ref`.

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -115,6 +115,13 @@ export default class Popover extends Component<PublicPopoverProps, PublicPopover
     isVisible: false
   }
 
+  requestClose(): void {
+    if (this.props.onRequestClose) this.props.onRequestClose();
+    this.setState({
+      isVisible: false
+    });
+  }
+
   private sourceRef: RefObject<View> = React.createRef();
 
   render(): ReactNode {


### PR DESCRIPTION
The main motivation here is shorter code and the possibility to wrap this component in a component that passes its own `from` value