### PR TITLE
Prevent errors being thrown when ref is not set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,6 @@ project.xcworkspace
 #
 node_modules/
 npm-debug.log
-
+.history/
 *.swp
 .dccache

--- a/src/AdaptivePopover.tsx
+++ b/src/AdaptivePopover.tsx
@@ -229,6 +229,7 @@ export default class AdaptivePopover extends Component<AdaptivePopoverProps, Ada
     let rect: Rect;
     count = 0;
     do {
+      if (!this._isMounted || !fromRef.current) return;
       rect = await getRectForRef(fromRef);
       if ([rect.x, rect.y, rect.width, rect.height].every(i => i === undefined)) {
         this.debug('calculateRectFromRef - rect not found, all properties undefined');

--- a/src/JSModalPopover.tsx
+++ b/src/JSModalPopover.tsx
@@ -44,8 +44,12 @@ export default class JSModalPopover extends Component<JSModalPopoverProps, Modal
               this.setState({ visible: false });
             }}
             getDisplayAreaOffset={async () => {
-              const rect = await getRectForRef(this.containerRef);
-              return new Point(rect.x, rect.y);
+              try {
+                const rect = await getRectForRef(this.containerRef);
+                return new Point(rect.x, rect.y);
+              } catch (err: unknown) {
+                return new Point(0, 0);
+              }
             }}
           />
         </View>

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -41,12 +41,6 @@ export async function waitForChange(
   } while (first.equals(second));
 }
 
-export async function waitForNewRect(ref: RefType, initialRect: Rect): Promise<Rect> {
-  await waitForChange(() => getRectForRef(ref), () => Promise.resolve(initialRect));
-  const rect = await getRectForRef(ref);
-  return rect;
-}
-
 export function sizeChanged(a: Size | null, b: Size | null): boolean {
   if (!a || !b) return false;
   return Math.round(a.width) !== Math.round(b.width) ||


### PR DESCRIPTION
If `ref.current` is not set then react-native-popover-view throws an error. This results in a lot of noise in error tracking such as Sentry or Bugsnag. 

This commit prevents the spurious errors from being thrown.