### PR TITLE
Fix from prop type

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -13,8 +13,8 @@ export interface PublicPopoverProps extends Omit<PopoverProps, 'displayArea' | '
   mode?: Mode;
   from?:
     | Rect
-    | RefObject<View>
-    | ((sourceRef: RefObject<View>, openPopover: () => void) => ReactNode)
+    | RefObject<Component>
+    | ((sourceRef: RefObject<Component>, openPopover: () => void) => ReactNode)
     | ReactNode
     | Point;
   testID?: ViewProps['testID'];


### PR DESCRIPTION
Fix from prop type only picking up views, which do not have an onPress prop.

## Context
After upgrading to RN 0.72 the library started complaining about the `from` props that were deemed valid before.
I couldn't find any way of setting them properly without changing the type to a more generic one, hence this PR.