### PR TITLE
fix: fix #181 - use measureInWindow of the ref instead of NativeModules

### DIFF
--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -1,19 +1,18 @@
-import { RefObject, ComponentClass, Component } from 'react';
-import { NativeModules, findNodeHandle, StyleProp, ViewStyle, StyleSheet } from 'react-native';
+import { RefObject } from 'react';
+import { StyleProp, ViewStyle, StyleSheet } from 'react-native';
 import { Placement, Point, Rect, Size } from './Types';
 import { DEFAULT_ARROW_SIZE, DEFAULT_BORDER_RADIUS } from './Constants';
 
-// Need any here to match signature of findNodeHandle
 // eslint-disable-next-line
-type RefType = RefObject<number | Component<any, any, any> | ComponentClass<any, any> | null>;
+type RefType = RefObject<{
+  measureInWindow: (callback: (x: number, y: number, width: number, height: number) => void) => void
+}>;
 
 export function getRectForRef(ref: RefType): Promise<Rect> {
   return new Promise((resolve, reject) => {
     if (ref.current) {
-      NativeModules.UIManager.measure(
-        findNodeHandle(ref.current),
-        (_1: unknown, _2: unknown, width: number, height: number, x: number, y: number) =>
-          resolve(new Rect(x, y, width, height))
+      ref.current.measureInWindow((x: number, y: number, width: number, height: number) =>
+        resolve(new Rect(x, y, width, height))
       );
     } else {
       reject(new Error('getRectForRef - current is not set'));


### PR DESCRIPTION
`NativeModules` is not working in the new architecture, so using the `measureInWindow` method on the ref as suggested by the react-native documentation [here](https://reactnative.dev/blog/2024/10/23/the-new-architecture-is-here#uselayouteffect) and [here](https://reactnative.dev/docs/legacy/direct-manipulation#measureinwindowcallback).