### PR TITLE
fix: popover not showing when using new architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,7 @@ onPositionChange  | function |             | Callback to be fired when the popov
 animationConfig   | object   |             | An object containing any configuration options that can be passed to Animated.timing (e.g. `{ duration: 600, easing: Easing.inOut(Easing.quad) }`).  The configuration options you pass will override the defaults for all animations.
 displayArea       | rect     |             | Area where the popover is allowed to be displayed.  By default, this will be automatically calculated to be the size of the display, or the size of the parent component if mode is not 'rn-modal'.
 displayAreaInsets | object   |             | Insets to apply to the display area.  The Popover will not be allowed to go beyond the display area minus the insets.
-statusBarTranslucent | bool  |             | For 'rn-modal' mode on Android only. Determines whether the background should go under the status bar. Passed through to RN `Modal` component, see [their docs](https://reactnative.dev/docs/modal#statusbartranslucent-1) as well.
-verticalOffset    | number   | 0           | The amount to vertically shift the popover on the screen, for use in correcting an occasional issue on Android.  In certain Android configurations, you may need to apply a `verticalOffset` of `-StatusBar.currentHeight` for the popover to originate from the correct place.  For shifting the popover in other situations, the `offset` prop should be used.
+statusBarTranslucent | bool  | true        | For 'rn-modal' mode on Android only. Determines whether the background should go under the status bar. Passed through to RN `Modal` component, see [their docs](https://reactnative.dev/docs/modal#statusbartranslucent-1) as well.
 debug             | bool     | false       | Set this to `true` to turn on debug logging to the console.  This is useful for figuring out why a Popover isn't showing.
 
 ### <a name="from"/>From
@@ -408,20 +407,6 @@ If on an **Android device**, try adding these props to the component whose `ref`
 * `collapsable={false}`
 
 See https://github.com/facebook/react-native/issues/3282 and https://github.com/SteffeyDev/react-native-popover-view/issues/28 for more info.
-
-#### Android vertical positioning incorrect
-
-Depending on how your app is configured, you may need to use the following `verticalOffset` prop to correctly position the popover on Android:
-```
-import { Platform, StatusBar, ... } from 'react-native';
-
-...
-
-  <Popover
-    {...otherProps}
-    verticalOffset={Platform.OS === 'android' ? -StatusBar.currentHeight : 0 }
-  />
-```
 
 #### Error when passing a functional component to the `from` prop
 

--- a/src/AdaptivePopover.tsx
+++ b/src/AdaptivePopover.tsx
@@ -1,6 +1,6 @@
 import React, { Component, ReactNode, RefObject } from 'react';
-import { Dimensions, EmitterSubscription, Keyboard, View } from 'react-native';
-import { DEBUG, isIOS } from './Constants';
+import { Dimensions, EmitterSubscription, Keyboard, Platform, StatusBar, View } from 'react-native';
+import { DEBUG, DEFAULT_STATUS_BAR_TRANSLUCENT, isIOS } from './Constants';
 import { Point, PopoverProps, Rect } from './Types';
 import { getChangedProps, getRectForRef } from './Utility';
 import BasePopover from './BasePopover';
@@ -222,7 +222,14 @@ export default class AdaptivePopover extends Component<AdaptivePopoverProps, Ada
       if (count++ > 20) return;
     }
 
-    const verticalOffset = (this.props.verticalOffset ?? 0) - displayAreaOffset.y;
+    const shouldAdjustForAndroidStatusBar =
+      Platform.OS === 'android' &&
+      (this.props.statusBarTranslucent ?? DEFAULT_STATUS_BAR_TRANSLUCENT);
+    const verticalOffsetAndroidAdjustment =
+      shouldAdjustForAndroidStatusBar
+        ? (StatusBar.currentHeight ?? 0)
+        : 0;
+    const verticalOffset = verticalOffsetAndroidAdjustment - displayAreaOffset.y;
     const horizontalOffset = -displayAreaOffset.x;
 
     this.debug('calculateRectFromRef - waiting for ref to move from', initialRect);

--- a/src/BasePopover.tsx
+++ b/src/BasePopover.tsx
@@ -62,7 +62,7 @@ export default class BasePopover extends Component<BasePopoverProps, BasePopover
 
   componentDidUpdate(prevProps: BasePopoverProps): void {
     // Make sure a value we care about has actually changed
-    const importantProps = ['isVisible', 'fromRect', 'displayArea', 'verticalOffset', 'offset', 'placement'];
+    const importantProps = ['isVisible', 'fromRect', 'displayArea', 'offset', 'placement'];
     const changedProps = getChangedProps(this.props, prevProps, importantProps);
     if (!changedProps.length) return;
     this.debug('[BasePopover] componentDidUpdate - changedProps', changedProps);

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -5,6 +5,7 @@ export const MULTIPLE_POPOVER_WARNING = `Popover Warning - Can't Show - Attempte
 
 export const DEFAULT_ARROW_SIZE = new Size(16, 8);
 export const DEFAULT_BORDER_RADIUS = 3;
+export const DEFAULT_STATUS_BAR_TRANSLUCENT = true;
 export const POPOVER_MARGIN = 10;
 
 export const DEBUG = false;

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import { View, ViewProps } from 'react-native';
 import { Rect, PopoverProps, Placement, Mode, Point, Size } from './Types';
-import { DEFAULT_ARROW_SIZE } from './Constants';
+import { DEFAULT_ARROW_SIZE, DEFAULT_STATUS_BAR_TRANSLUCENT } from './Constants';
 import JSModalPopover from './JSModalPopover';
 import RNModalPopover from './RNModalPopover';
 
@@ -75,7 +75,6 @@ export default class Popover extends Component<PublicPopoverProps, PublicPopover
       )
     ]),
     animationConfig: PropTypes.object,
-    verticalOffset: PropTypes.number,
 
     // style
     popoverStyle: ViewPropTypes.style,
@@ -104,7 +103,7 @@ export default class Popover extends Component<PublicPopoverProps, PublicPopover
   static defaultProps: Partial<PublicPopoverProps> = {
     mode: Mode.RN_MODAL,
     placement: Placement.AUTO,
-    verticalOffset: 0,
+    statusBarTranslucent: DEFAULT_STATUS_BAR_TRANSLUCENT,
     popoverStyle: {},
     arrowSize: DEFAULT_ARROW_SIZE,
     backgroundStyle: {},

--- a/src/RNModalPopover.tsx
+++ b/src/RNModalPopover.tsx
@@ -1,11 +1,10 @@
 import React, { RefObject, Component, ReactNode } from 'react';
 import { View, Modal } from 'react-native';
 import AdaptivePopover from './AdaptivePopover';
-import { MULTIPLE_POPOVER_WARNING } from './Constants';
+import { DEFAULT_STATUS_BAR_TRANSLUCENT, MULTIPLE_POPOVER_WARNING } from './Constants';
 import { PopoverProps, Rect, ModalPopoverState, Point } from './Types';
 
 interface RNModalPopoverProps extends PopoverProps {
-  statusBarTranslucent?: boolean
   fromRect?: Rect;
   fromRef?: RefObject<View>;
   displayArea?: Rect;
@@ -55,7 +54,7 @@ export default class RNModalPopover extends Component<RNModalPopoverProps, Modal
         supportedOrientations={['portrait', 'portrait-upside-down', 'landscape']}
         hardwareAccelerated={true}
         visible={visible}
-        statusBarTranslucent={statusBarTranslucent}
+        statusBarTranslucent={statusBarTranslucent ?? DEFAULT_STATUS_BAR_TRANSLUCENT}
         onShow={() => {
           RNModalPopover.isShowingInModal = true;
         }}

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -39,7 +39,6 @@ export type PopoverProps = {
   placement?: Placement | Array<Placement>;
   animationConfig?: Partial<Animated.TimingAnimationConfig>;
   offset?: number;
-  verticalOffset?: number;
   displayArea?: Rect;
   displayAreaInsets?: Insets;
 
@@ -49,6 +48,7 @@ export type PopoverProps = {
   backgroundStyle?: StyleProp<ViewStyle>;
   arrowShift?: number;
   arrowSize?: Size;
+  statusBarTranslucent?: boolean;
 
   // lifecycle
   onOpenStart?: () => void;

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -1,18 +1,17 @@
-import { RefObject, ComponentClass, Component } from 'react';
-import { NativeModules, findNodeHandle, StyleProp, ViewStyle, StyleSheet } from 'react-native';
+import { RefObject } from 'react';
+import { MeasureInWindowOnSuccessCallback, StyleProp, ViewStyle, StyleSheet } from 'react-native';
 import { Placement, Point, Rect, Size } from './Types';
 import { DEFAULT_ARROW_SIZE, DEFAULT_BORDER_RADIUS } from './Constants';
 
-// Need any here to match signature of findNodeHandle
-// eslint-disable-next-line
-type RefType = RefObject<number | Component<any, any, any> | ComponentClass<any, any> | null>;
+type RefType = RefObject<{
+  measureInWindow: (callback: MeasureInWindowOnSuccessCallback) => void
+}>;
 
 export function getRectForRef(ref: RefType): Promise<Rect> {
   return new Promise((resolve, reject) => {
     if (ref.current) {
-      NativeModules.UIManager.measure(
-        findNodeHandle(ref.current),
-        (_1: unknown, _2: unknown, width: number, height: number, x: number, y: number) =>
+      ref.current.measureInWindow(
+        (x: number, y: number, width: number, height: number) =>
           resolve(new Rect(x, y, width, height))
       );
     } else {


### PR DESCRIPTION
`NativeModules.UIManager.measure(...)` does not work when new architecture is enabled.
`ref.current.measureInWindow(...)` works on both old and new architecture and returns the same values, except one case: when the status bar is translucent on Android, it substracts the height of the status bar from the "y" value (see https://github.com/SteffeyDev/react-native-popover-view/pull/182#issuecomment-2537382284). This means we need to adjust the verticalOffset on Android when the status bar is translucent. To ensure that we always know whether the status bar is translucent or not, we'll default the value of statusBarTranslucent to true when not passed explicitly (which is more similar to iOS) instead of passing undefined to RN Modal.
Since the only intended purpose the `verticalOffset` prop was to correct manually the position on Android and now it's adjusted internally, we don't need that prop anymore and we are removing it.