### PR TITLE
Improve screenreader support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com:steffeydev/react-native-popover-view.git"
+    "url": "git@github.com:steffeydev/react-native-popover-view.git"
   },
   "devDependencies": {
     "@types/node": "^14.0.11",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:steffeydev/react-native-popover-view.git"
+    "url": "github.com:steffeydev/react-native-popover-view.git"
   },
   "devDependencies": {
     "@types/node": "^14.0.11",

--- a/src/BasePopover.tsx
+++ b/src/BasePopover.tsx
@@ -478,7 +478,11 @@ export default class BasePopover extends Component<BasePopoverProps, BasePopover
       styles.popoverContent.backgroundColor;
 
     return (
-      <View pointerEvents="box-none" style={[styles.container, { top: -1 * FIX_SHIFT }]}>
+      <View
+        pointerEvents="box-none"
+        accessibilityViewIsModal
+        importantForAccessibility="yes"
+        style={[styles.container, { top: -1 * FIX_SHIFT }]}>
         <View
           pointerEvents="box-none"
           style={[styles.container, { top: FIX_SHIFT, flex: 1 }]}
@@ -489,9 +493,9 @@ export default class BasePopover extends Component<BasePopoverProps, BasePopover
             evt.nativeEvent.layout.height
           ))}
         />
-        <Animated.View pointerEvents="box-none" style={containerStyle}>
+        <Animated.View pointerEvents="box-none" style={containerStyle} onAccessibilityEscape={this.props.onRequestClose}>
           {this.props.showBackground !== false && (
-            <TouchableWithoutFeedback onPress={this.props.onRequestClose}>
+            <TouchableWithoutFeedback onPress={this.props.onRequestClose} accessibilityRole="button" accessible>
               <Animated.View style={backgroundStyle} />
             </TouchableWithoutFeedback>
           )}


### PR DESCRIPTION
These changes will:

- Inform the device that the background acts as a button
- Inform the device that the popover is a sort of modal  in order to ignore siblings (`accessibilityViewIsModal` for iOS and `importantForAccessibility="true"` for Android)
- Adds the iOS specific `onAccessibilityEscape` to the background to enable the user to close the tooltip using the escape gesture